### PR TITLE
Use context managers for file IO

### DIFF
--- a/lpmd2lmp.py
+++ b/lpmd2lmp.py
@@ -32,7 +32,8 @@ for i in range(N):
 to_file = ''
 
 if ARGS.template:
-    template_file = open(ARGS.template, 'r').read()
+    with open(ARGS.template, 'r') as f:
+        template_file = f.read()
     to_file = template_file
     to_file = to_file.replace('ALL_ATOM_STRING', ALL_ATOMS_STRING)
     to_file = to_file.replace('CELL_STRING', CELL_STRING)
@@ -42,6 +43,6 @@ else:
     to_file += CELL_STRING
     to_file += ALL_ATOMS_STRINGS
 
-ofile = open(str(ARGS.out), 'w')
-ofile.write(to_file)
+with open(str(ARGS.out), 'w') as ofile:
+    ofile.write(to_file)
 

--- a/parselpmd2.py
+++ b/parselpmd2.py
@@ -61,59 +61,61 @@ class LPMD2:
 
     def Read(self, path):
         self.valid = False
-        f = open(path, 'r')
-        header1 = f.readline().strip()
-        if header1 != 'LPMD 2.0 L': raise WrongHeader(header1)
-        header2 = f.readline().strip()
-        if header2 == '': raise WrongHeader(header2)
-        hspl = [x.strip() for x in header2.split()]
-        if hspl[0] != 'HDR': raise WrongHeader(header2)
-        self.tags = hspl[1:]
-        while True:
-              atoms = f.readline()
-              if atoms == '': break
-              this_config = Configuration(self.tags)
-              cellvectors = [float(x.strip()) for x in f.readline().split()]
-              for q in range(3): this_config.cell[q] = tuple(cellvectors[3*q:3*q+3])
-              for i in range(int(atoms)):
-                  line = f.readline()
-                  if line == '': raise UnexpectedEndOfFile(path)
-                  this_config.append(SplitLine(line))
-              self.configs.append(this_config)
+        with open(path, 'r') as f:
+            header1 = f.readline().strip()
+            if header1 != 'LPMD 2.0 L': raise WrongHeader(header1)
+            header2 = f.readline().strip()
+            if header2 == '': raise WrongHeader(header2)
+            hspl = [x.strip() for x in header2.split()]
+            if hspl[0] != 'HDR': raise WrongHeader(header2)
+            self.tags = hspl[1:]
+            while True:
+                  atoms = f.readline()
+                  if atoms == '': break
+                  this_config = Configuration(self.tags)
+                  cellvectors = [float(x.strip()) for x in f.readline().split()]
+                  for q in range(3):
+                      this_config.cell[q] = tuple(cellvectors[3*q:3*q+3])
+                  for i in range(int(atoms)):
+                      line = f.readline()
+                      if line == '': raise UnexpectedEndOfFile(path)
+                      this_config.append(SplitLine(line))
+                  self.configs.append(this_config)
         self.valid = (len(self.configs) > 0)
 
     def ReadInPlace(self, path, temp_config, callback):
         self.valid = False
-        f = open(path, 'r')
-        header1 = f.readline().strip()
-        if header1 != 'LPMD 2.0 L': raise WrongHeader(header1)
-        header2 = f.readline().strip()
-        if header2 == '':raise WrongHeader(header2)
-        hspl = [x.strip() for x in header2.split()]
-        if hspl[0] != 'HDR': raise WrongHeader(header2)
-        self.tags = hspl[1:]
-        while True:
-              atoms = f.readline()
-              if atoms == '': break
-              this_config = Configuration(self.tags)
-              cellvectors = [float(x.strip()) for x in f.readline().split()]
-              for q in range(3): this_config.cell[q] = tuple(cellvectors[3*q:3*q+3])
-              for i in range(int(atoms)):
-                  line = f.readline()
-                  if line == '': raise UnexpectedEndOfFile(path)
-                  this_config.append(SplitLine(line))
-              temp_config[0] = this_config
-              callback(this_config)
+        with open(path, 'r') as f:
+            header1 = f.readline().strip()
+            if header1 != 'LPMD 2.0 L': raise WrongHeader(header1)
+            header2 = f.readline().strip()
+            if header2 == '':raise WrongHeader(header2)
+            hspl = [x.strip() for x in header2.split()]
+            if hspl[0] != 'HDR': raise WrongHeader(header2)
+            self.tags = hspl[1:]
+            while True:
+                  atoms = f.readline()
+                  if atoms == '': break
+                  this_config = Configuration(self.tags)
+                  cellvectors = [float(x.strip()) for x in f.readline().split()]
+                  for q in range(3):
+                      this_config.cell[q] = tuple(cellvectors[3*q:3*q+3])
+                  for i in range(int(atoms)):
+                      line = f.readline()
+                      if line == '': raise UnexpectedEndOfFile(path)
+                      this_config.append(SplitLine(line))
+                  temp_config[0] = this_config
+                  callback(this_config)
         self.Valid = True
 
     def Write(self, path):
-        f = open(path, 'w')
-        f.write('LPMD 2.0 L\nHDR '+' '.join(self.tags)+'\n')
-        for conf in self.configs:
-            f.write('%d\n' % len(conf)) 
-            cellvectors = list(conf.cell[0])+list(conf.cell[1])+list(conf.cell[2])
-            f.write(' '.join(str(x) for x in cellvectors)+'\n')
-            for i in range(len(conf)):
-                for t in self.tags: f.write(' '+cfmt(conf.Tag(t, i)))
-                f.write('\n')
+        with open(path, 'w') as f:
+            f.write('LPMD 2.0 L\nHDR '+' '.join(self.tags)+'\n')
+            for conf in self.configs:
+                f.write('%d\n' % len(conf))
+                cellvectors = list(conf.cell[0])+list(conf.cell[1])+list(conf.cell[2])
+                f.write(' '.join(str(x) for x in cellvectors)+'\n')
+                for i in range(len(conf)):
+                    for t in self.tags: f.write(' '+cfmt(conf.Tag(t, i)))
+                    f.write('\n')
 


### PR DESCRIPTION
## Summary
- swap to `with open` when reading templates and writing output
- use `with open` in `parselpmd2.py` file operations

## Testing
- `python3 -m py_compile arguments.py lmp_cell.py lpmd2lmp.py parselpmd2.py`

------
https://chatgpt.com/codex/tasks/task_e_683f8a34e8a4832f848907b07f584e37